### PR TITLE
Make CLI binary executable

### DIFF
--- a/packages/taintflow-cli/package.json
+++ b/packages/taintflow-cli/package.json
@@ -18,7 +18,7 @@
     "dist/index.js"
   ],
   "scripts": {
-    "prepare": "rm -rf dist && tsc"
+    "prepare": "rm -rf dist && tsc && chmod +x dist/index.js"
   },
   "dependencies": {
     "@taintflow/babel-plugin-transform": "^0.0.0",

--- a/packages/taintflow-cli/src/index.ts
+++ b/packages/taintflow-cli/src/index.ts
@@ -10,7 +10,7 @@ const program = new Command("taintflow");
 program.outputHelp = function (this: typeof program) {
     const email = pkg.author.match(/<.*>/)[0];
     console.log(
-        "  %s by %s",
+        "%s by %s",
         chalk.dim.cyan("taintflow"),
         chalk.bold(email),
     );


### PR DESCRIPTION
This change fixes the `permission denied` error when running `yarn taintflow`.