### PR TITLE
Change `Mixed` to `unknown`

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "nyc": "^14.1.0",
     "tslint": "^5.16.0",
     "tslint-microsoft-contrib": "^6.1.1",
-    "typescript": "^3.4.5"
+    "typescript": "^3.6.2"
   },
   "nyc": {
     "check-coverage": true,

--- a/packages/taintflow-simulator/test/evaluators/MemberExpression.spec.ts
+++ b/packages/taintflow-simulator/test/evaluators/MemberExpression.spec.ts
@@ -1,4 +1,4 @@
-import {should} from "chai";
+import {expect, should} from "chai";
 import "mocha";
 
 import {Identifier, RValue} from "@taintflow/types";
@@ -23,7 +23,7 @@ describe("evaluators.MemberExpression", () => {
         });
 
         it("should evaluate", () => {
-            expr.evaluate().value.should.equal(foo.bar);
+            expect(expr.evaluate().value).equal(foo.bar);
         });
 
         it("should be assignable", () => {

--- a/packages/taintflow-types/src/taxonomy.ts
+++ b/packages/taintflow-types/src/taxonomy.ts
@@ -1,4 +1,4 @@
-export type Mixed = {} | undefined;
+export type Mixed = unknown;
 
 export type QuotedExpression<Value> =
     () => EvaluatedExpression<Value>;


### PR DESCRIPTION
This change fixes the following error after the transition to TypeScript 3.0+:

```
src/evaluators/MemberExpression.ts(21,12): error TS2416: Property 'evaluate' in type 'MemberExpression<Object, Property>' is not assignable to the same property in base type 'EvaluatingNode<Mixed>'.
  Type '() => PropertyReference<Object, unknown>' is not assignable to type '() => EvaluatedExpression<Mixed>'.
    Type 'PropertyReference<Object, unknown>' is not assignable to type 'EvaluatedExpression<Mixed>'.
      Type 'PropertyReference<Object, unknown>' is not assignable to type 'PropertyReference<Mixed, Mixed>'.
        Type 'unknown' is not assignable to type 'Mixed'.
          Type 'unknown' is not assignable to type '{}'.
test/evaluators/MemberExpression.spec.ts(26,13): error TS2571: Object is of type 'unknown'.```